### PR TITLE
Add publishing to a custom publication path

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nuget/Utils/NugetPublishCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/Utils/NugetPublishCommand.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.nuget.Utils;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.nuget.NugetGlobalConfiguration;
 import org.jenkinsci.plugins.nuget.NugetPublication;
 
@@ -12,20 +13,33 @@ import org.jenkinsci.plugins.nuget.NugetPublication;
 public class NugetPublishCommand extends NugetCommandBase {
     private FilePath packageFile;
     private NugetPublication publication;
+    private String publishPath;
 
-    public NugetPublishCommand(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir, FilePath packageFile, NugetPublication publication) {
+    public NugetPublishCommand(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir, FilePath packageFile, String publishPath, NugetPublication publication) {
         super(listener, configuration, workDir);
         this.packageFile = packageFile;
         this.publication = publication;
+        this.publishPath = publishPath;
     }
 
     @Override
     protected void enrichArguments(ArgumentListBuilder builder) {
+  	String fullUrl = publication.getUrl();
+
+        //only append the path if it exists        
+        if ( publishPath != null && !publishPath.trim().isEmpty() ) {
+            //ensure we have a separator
+            if (!StringUtils.endsWith(fullUrl, "/")) {
+                fullUrl += "/";
+	    }
+            fullUrl += publishPath;
+        }
+	
         builder.add("push");
         builder.add(packageFile);
         builder.addMasked(publication.getApiKey());
         builder.add("-Source");
-        builder.add(publication.getUrl());
+        builder.add(fullUrl);
         builder.add(NON_INTERACTIVE);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nuget/Utils/Validations.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/Utils/Validations.java
@@ -11,4 +11,15 @@ public class Validations {
     public static FormValidation mandatory(String value) {
         return StringUtils.isBlank(value) ? FormValidation.error(Messages.NugetGlobalConfiguration_MandatoryProperty()) : FormValidation.ok();
     }
+
+    public static FormValidation urlPath(String value) {
+        String trimmedValue = StringUtils.trim(value);
+        if ( StringUtils.startsWith(trimmedValue, "/") || StringUtils.endsWith(trimmedValue, "/") ) {
+            return FormValidation.error(Messages.NugetPublisher_DontStartOrEndWithSlash());
+        } else if ( StringUtils.containsAny(trimmedValue, "\\")) {
+            return FormValidation.error(Messages.NugetPublisher_BackSlash());
+        } else {
+            return FormValidation.ok();
+        } 
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisher.java
@@ -17,6 +17,7 @@ import org.jenkinsci.plugins.nuget.NugetPublication;
 import org.jenkinsci.plugins.nuget.Utils.Validations;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,13 +32,15 @@ public class NugetPublisher extends Recorder {
 
     private String name;
     private String packagesPattern;
+    private String publishPath;
     private String nugetPublicationName;
     private String packagesExclusionPattern;
 
     @DataBoundConstructor
-    public NugetPublisher(String name, String packagesPattern, String nugetPublicationName, String packagesExclusionPattern) {
+    public NugetPublisher(String name, String packagesPattern, String publishPath, String nugetPublicationName, String packagesExclusionPattern) {
         this.name = name;
         this.packagesPattern = packagesPattern;
+        this.publishPath = StringUtils.trim(publishPath);
         this.nugetPublicationName = nugetPublicationName;
         this.packagesExclusionPattern = packagesExclusionPattern;
     }
@@ -56,7 +59,7 @@ public class NugetPublisher extends Recorder {
 
         String pattern = Util.replaceMacro(packagesPattern, build.getEnvironment(listener));
         String exclusionPattern = Util.replaceMacro(packagesExclusionPattern, build.getEnvironment(listener));
-        NugetPublisherCallable callable = new NugetPublisherCallable(pattern, exclusionPattern, listener, configuration, publication);
+        NugetPublisherCallable callable = new NugetPublisherCallable(pattern, exclusionPattern, listener, configuration, publishPath, publication);
         List<PublicationResult> results = workspaceRoot.act(callable);
         if (results.size() > 0) {
             build.addAction(new NugetPublisherRunAction(name, results));
@@ -85,6 +88,10 @@ public class NugetPublisher extends Recorder {
 
     public String getPackagesPattern() {
         return packagesPattern;
+    }
+
+    public String getPublishPath() {
+        return publishPath;
     }
 
     public String getPackagesExclusionPattern() {
@@ -127,6 +134,10 @@ public class NugetPublisher extends Recorder {
 
         public FormValidation doCheckNugetPublicationName(@QueryParameter String value) {
             return Validations.mandatory(value);
+        }
+        
+        public FormValidation doCheckPublishPath(@QueryParameter String value) {
+            return Validations.urlPath(value);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisher.java
@@ -52,19 +52,23 @@ public class NugetPublisher extends Recorder {
 
     @Override
      public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        listener.getLogger().format("Starting %s publication%n", name);
+       
+        //expand parameters 
+        String expandedName = Util.replaceMacro(name, build.getEnvironment(listener));
+        String pattern = Util.replaceMacro(packagesPattern, build.getEnvironment(listener));
+        String exclusionPattern = Util.replaceMacro(packagesExclusionPattern, build.getEnvironment(listener));
+        String expandedPublishPath = Util.replaceMacro(publishPath, build.getEnvironment(listener));
+        
+        listener.getLogger().format("Starting %s publication%n", expandedName);
         FilePath workspaceRoot = getWorkspace(build);
         NugetGlobalConfiguration configuration = GlobalConfiguration.all().get(NugetGlobalConfiguration.class);
         NugetPublication publication = NugetPublication.get(nugetPublicationName);
-
-        String pattern = Util.replaceMacro(packagesPattern, build.getEnvironment(listener));
-        String exclusionPattern = Util.replaceMacro(packagesExclusionPattern, build.getEnvironment(listener));
-        NugetPublisherCallable callable = new NugetPublisherCallable(pattern, exclusionPattern, listener, configuration, publishPath, publication);
+        NugetPublisherCallable callable = new NugetPublisherCallable(pattern, exclusionPattern, listener, configuration, expandedPublishPath, publication);
         List<PublicationResult> results = workspaceRoot.act(callable);
         if (results.size() > 0) {
-            build.addAction(new NugetPublisherRunAction(name, results));
+            build.addAction(new NugetPublisherRunAction(expandedName, results));
         }
-        listener.getLogger().format("Ended %s publication%n", name);
+        listener.getLogger().format("Ended %s publication%n", expandedName);
         checkErrors(results);
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisherCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisherCallable.java
@@ -23,13 +23,15 @@ import java.util.List;
  */
 class NugetPublisherCallable extends MasterToSlaveFileCallable<List<PublicationResult>> {
     private final String packagesPattern;
+    private final String publishPath;
     private final String packagesExclusionPattern;
     private final BuildListener listener;
     private final NugetGlobalConfiguration configuration;
     private final NugetPublication publication;
 
-    NugetPublisherCallable(String packagesPattern, String packagesExclusionPattern, BuildListener listener, NugetGlobalConfiguration configuration, NugetPublication publication) {
+    NugetPublisherCallable(String packagesPattern, String packagesExclusionPattern, BuildListener listener, NugetGlobalConfiguration configuration, String publishPath, NugetPublication publication) {
         this.packagesPattern = packagesPattern;
+        this.publishPath = publishPath;
         this.packagesExclusionPattern = packagesExclusionPattern;
         this.listener = listener;
         this.configuration = configuration;
@@ -47,6 +49,7 @@ class NugetPublisherCallable extends MasterToSlaveFileCallable<List<PublicationR
                     configuration,
                     new FilePath(file),
                     new FilePath(packageFile),
+                    publishPath,
                     publication);
             boolean success = publishCommand.execute();
             results.add(new PublicationResult(packageFile.getName(), success));

--- a/src/main/resources/org/jenkinsci/plugins/nuget/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/Messages.properties
@@ -5,3 +5,7 @@ NugetTrigger.DiplayName=Build on NuGet updates
 NugetGlobalConfiguration.MandatoryProperty=This property is mandatory.
 
 NugetPublisher.DisplayName=Publish NuGet packages
+
+NugetPublisher.DontStartOrEndWithSlash=Cannot start or end with a slash.
+NugetPublisher.BackSlash=Cannot contain backslashes.
+

--- a/src/main/resources/org/jenkinsci/plugins/nuget/Messages_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/Messages_fr.properties
@@ -5,3 +5,6 @@ NugetTrigger.DiplayName=Construire sur update de package NuGet
 NugetGlobalConfiguration.MandatoryProperty=Cette propriété est obligatoire.
 
 NugetPublisher.DisplayName=Publier des packages NuGet
+
+NugetPublisher.DontStartOrEndWithSlash=Vous ne pouvez pas commencer ou se terminer par une barre oblique.
+NugetPublisher.BackSlash=Ne peut pas contenir backslashes.

--- a/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.jelly
@@ -23,4 +23,7 @@
   <f:entry title="${%FileExclusionPattern}" description="${%FileExclusionPatternDescription}" field="packagesExclusionPattern">
     <f:textbox value="${instance.packagesExclusionPattern}"/>
   </f:entry>
+  <f:entry title="${%publishPath}" description="${%publishPathDescription}" field="publishPath">
+    <f:textbox value="${instance.publishPath}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.properties
@@ -5,3 +5,5 @@ FilePattern=Packages to publish
 FilePatternDescription=A path relative to <a href='ws/'>the workspace root</a>, an Ant fileset pattern, or an environment variable.
 FileExclusionPattern=Packages NOT to publish
 FileExclusionPatternDescription=A path relative to <a href='ws/'>the workspace root</a>, an Ant fileset pattern, or an environment variable.
+publishPath=Publish Path
+publishPathDescription=A path, relative to the publication, where your package will be published.

--- a/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config_fr.properties
@@ -5,3 +5,5 @@ FilePattern=Packages à publier
 FilePatternDescription=Chemin relatif à la racine du <a href='ws/'>workspace</a>, un patron Ant pour un fileset ou une variable d'environnement.
 FileExclusionPattern=Packages à ne PAS publier
 FileExclusionPatternDescription=Chemin relatif à la racine du <a href='ws/'>workspace</a>, un patron Ant pour un fileset ou une variable d'environnement.
+publishPath=Publier Chemin
+publishPathDescription=Un chemin, par rapport à la publication, où votre colis sera publié.


### PR DESCRIPTION
This allows for the NuGet publication's relative path to be configured in the job, with basic validation.  I used google-translate for the french properties/messages---they might not be the best.

Let me know if you have any questions/concerns.