### PR TITLE
Add the ability to set the verbosity level for the nuget command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPromotionPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPromotionPublisher.java
@@ -50,8 +50,8 @@ public class NugetPromotionPublisher extends NugetPublisher {
     private static final String PROMOTION_CLASS_NAME = "hudson.plugins.promoted_builds.Promotion";
 
     @DataBoundConstructor
-    public NugetPromotionPublisher(String name, String packagesPattern, String publishPath, String nugetPublicationName, String packagesExclusionPattern, boolean useWorkspaceInPromotion, boolean doNotFailIfNoPackagesArePublished) {
-        super(name, packagesPattern, publishPath, nugetPublicationName, packagesExclusionPattern, doNotFailIfNoPackagesArePublished);
+    public NugetPromotionPublisher(String name, String packagesPattern, String publishPath, String nugetPublicationName, String packagesExclusionPattern, boolean useWorkspaceInPromotion, boolean doNotFailIfNoPackagesArePublished, String nugetVerbosity) {
+        super(name, packagesPattern, publishPath, nugetPublicationName, packagesExclusionPattern, doNotFailIfNoPackagesArePublished, nugetVerbosity);
         this.useWorkspaceInPromotion = useWorkspaceInPromotion;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisherCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/publishers/NugetPublisherCallable.java
@@ -27,14 +27,16 @@ class NugetPublisherCallable extends MasterToSlaveFileCallable<List<PublicationR
     private final BuildListener listener;
     private final NugetGlobalConfiguration configuration;
     private final NugetPublication publication;
+    private final String nugetVerbosity;
 
-    NugetPublisherCallable(String packagesPattern, String packagesExclusionPattern, BuildListener listener, NugetGlobalConfiguration configuration, String publishPath, NugetPublication publication) {
+    NugetPublisherCallable(String packagesPattern, String packagesExclusionPattern, BuildListener listener, NugetGlobalConfiguration configuration, String publishPath, NugetPublication publication, String nugetVerbosity) {
         this.packagesPattern = packagesPattern;
         this.publishPath = publishPath;
         this.packagesExclusionPattern = packagesExclusionPattern;
         this.listener = listener;
         this.configuration = configuration;
         this.publication = publication;
+        this.nugetVerbosity = nugetVerbosity;
     }
 
     @Override
@@ -49,7 +51,8 @@ class NugetPublisherCallable extends MasterToSlaveFileCallable<List<PublicationR
                     new FilePath(file),
                     new FilePath(packageFile),
                     publishPath,
-                    publication);
+                    publication,
+                    nugetVerbosity);
             boolean success = publishCommand.execute();
             results.add(new PublicationResult(packageFile.getName(), success));
         }

--- a/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetCommandBase.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetCommandBase.java
@@ -15,17 +15,20 @@ abstract class NugetCommandBase {
 
     static final String NON_INTERACTIVE = "-NonInteractive";
     static final String PRE_RELEASE = "-Prerelease";
+    static final String VERBOSITY = "-Verbosity";
 
     int retryCount = 1;
     protected TaskListener listener;
     protected NugetGlobalConfiguration configuration;
     private FilePath workDir;
     protected boolean failed;
+    protected String nugetVerbosity;
 
-    NugetCommandBase(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir) {
+    NugetCommandBase(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir, String nugetVerbosity) {
         this.listener = listener;
         this.configuration = configuration;
         this.workDir = workDir;
+        this.nugetVerbosity = nugetVerbosity;
     }
 
     public boolean execute() throws IOException {
@@ -50,6 +53,11 @@ abstract class NugetCommandBase {
         Launcher.LocalLauncher launcher = new Launcher.LocalLauncher(listener);
         ArgumentListBuilder builder = new ArgumentListBuilder(getNugetExe());
         enrichArguments(builder);
+        if (nugetVerbosity != null && !nugetVerbosity.equals("")) {
+            builder.add(VERBOSITY);
+            // Possible values are normal (default), quiet, detailed
+            builder.add(nugetVerbosity);
+        }
         Launcher.ProcStarter starter = launcher
                 .launch()
                 .pwd(workDir)

--- a/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetGetLatestPackageVersionCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetGetLatestPackageVersionCommand.java
@@ -23,7 +23,7 @@ class NugetGetLatestPackageVersionCommand extends NugetCommandBase {
     private String version;
 
     NugetGetLatestPackageVersionCommand(TriggerLog log, NugetGlobalConfiguration configuration, FilePath workDir, String packageName, boolean checkPrerelease) {
-        super(log.getListener(), configuration, workDir);
+        super(log.getListener(), configuration, workDir, null);
         this.log = log;
         this.packageName = packageName;
         this.checkPrerelease = checkPrerelease;

--- a/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetPublishCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetPublishCommand.java
@@ -15,8 +15,8 @@ public class NugetPublishCommand extends NugetCommandBase {
     private NugetPublication publication;
     private String publishPath;
 
-    public NugetPublishCommand(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir, FilePath packageFile, String publishPath, NugetPublication publication) {
-        super(listener, configuration, workDir);
+    public NugetPublishCommand(TaskListener listener, NugetGlobalConfiguration configuration, FilePath workDir, FilePath packageFile, String publishPath, NugetPublication publication, String nugetVerbosity) {
+        super(listener, configuration, workDir, nugetVerbosity);
         this.packageFile = packageFile;
         this.publication = publication;
         this.publishPath = publishPath;

--- a/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.jelly
@@ -43,4 +43,7 @@
     <f:entry title="${%DoNotFailIfNoPackagesArePublished}" field="doNotFailIfNoPackagesArePublished">
         <f:checkbox value="${instance.doNotFailIfNoPackagesArePublished}"/>
     </f:entry>
+    <f:entry title="${%NugetVerbosity}" field="nugetVerbosity">
+        <f:select default="Normal" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/nuget/publishers/NugetPublisher/config.properties
@@ -1,4 +1,5 @@
 Name=Name
+NugetVerbosity=Verbosity
 NugetPublication=Publication
 NugetPublication.error=There are no NuGet publication configured.<br/>\
   Please configure a NuGet publication in the <a href="{0}/configure">system configuration</a>.


### PR DESCRIPTION
When we where looking into a problem regarding our local Nuget repository we had the need to turn up the verbosity level for the Nuget command line tool. This helped us to diagnose the problem and find out the cause. So we cleaned up our code changes and would like to contribute them back to the community.

We implemented a configuration UI for NugetPublisher, but the core functionality is in NugetCommandBase so that it can be used for other command as well going forward.

One thing is missing and that is localization for the key NugetVerbosity that was added to NugetPublisher/config.properties.