### PR TITLE
Merge release 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <jenkins.version>2.204.6</jenkins.version>
     <java.level>8</java.level>
     <checkstyle.version>3.1.1</checkstyle.version>
-    <mockito.version>3.9.0</mockito.version>
+    <mockito.version>3.8.0</mockito.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>nuget</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.1</version>
   <packaging>hpi</packaging>
   <name>Jenkins Nuget Plugin</name>
   <description>NuGet package updates trigger Jenkins builds</description>
@@ -34,7 +34,7 @@
     <connection>scm:git:git://github.com/jenkinsci/nuget-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/nuget-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nuget-plugin</url>
-    <tag>HEAD</tag>
+    <tag>nuget-1.1</tag>
   </scm>
   
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>nuget</artifactId>
-  <version>1.1</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins Nuget Plugin</name>
   <description>NuGet package updates trigger Jenkins builds</description>
@@ -34,7 +34,7 @@
     <connection>scm:git:git://github.com/jenkinsci/nuget-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/nuget-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nuget-plugin</url>
-    <tag>nuget-1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <jenkins-test-harness.version>2.6</jenkins-test-harness.version>
     <jenkins.version>1.625.3</jenkins.version>
     <xtrigger-lib.version>0.33</xtrigger-lib.version>
+    <mockito.version>3.9.0</mockito.version>
   </properties>
 
   <licenses>
@@ -68,6 +69,12 @@
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>xtrigger-lib</artifactId>
       <version>${xtrigger-lib.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>nuget</artifactId>
-  <version>1.0</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins Nuget Plugin</name>
   <description>NuGet package updates trigger Jenkins builds</description>
@@ -33,7 +33,7 @@
     <connection>scm:git:git://github.com/jenkinsci/nuget-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/nuget-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nuget-plugin</url>
-    <tag>nuget-1.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <developers>

--- a/src/main/java/org/jenkinsci/plugins/nuget/triggers/NugetTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/triggers/NugetTrigger.java
@@ -18,6 +18,7 @@ import hudson.model.Node;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 import org.jenkinsci.lib.xtrigger.AbstractTrigger;
 import org.jenkinsci.lib.xtrigger.XTriggerDescriptor;
@@ -51,6 +52,7 @@ public class NugetTrigger extends AbstractTrigger {
 
     @Override
     protected File getLogFile() {
+        Objects.requireNonNull(job, "job");
         return new File(job.getRootDir(), "nuget-polling.log");
     }
 

--- a/src/main/java/org/jenkinsci/plugins/nuget/triggers/NugetTriggerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/triggers/NugetTriggerAction.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.nuget.triggers;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.Action;
@@ -50,6 +51,7 @@ public class NugetTriggerAction implements Action {
     }
 
     @SuppressWarnings("unused")
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
     public void writeLogTo(XMLOutput out) throws IOException {
         new AnnotatedLargeText<>(getLogFile(), Charset.defaultCharset(), true, this).writeHtmlTo(0, out.asWriter());
     }

--- a/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetPackageCheckerVisitor.java
+++ b/src/main/java/org/jenkinsci/plugins/nuget/utils/NugetPackageCheckerVisitor.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.nuget.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import hudson.FilePath;
-import org.jenkinsci.lib.xtrigger.XTriggerLog;
 import org.jenkinsci.plugins.nuget.NugetGlobalConfiguration;
 import org.jenkinsci.plugins.nuget.triggers.logs.TriggerLog;
 import org.w3c.dom.Document;
@@ -18,7 +18,6 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -43,7 +42,9 @@ class NugetPackageCheckerVisitor extends SimpleFileVisitor<Path> {
         this.configuration = configuration;
         this.preReleaseChecked = preReleaseChecked;
         this.workspaceRoot = workspaceRoot;
-        builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        builder = factory.newDocumentBuilder();
     }
 
     @Override
@@ -100,5 +101,10 @@ class NugetPackageCheckerVisitor extends SimpleFileVisitor<Path> {
         NugetGetLatestPackageVersionCommand command = new NugetGetLatestPackageVersionCommand(log, configuration, workspaceRoot, packageName, preReleaseChecked);
         command.execute();
         return command.getVersion();
+    }
+
+    @VisibleForTesting
+    public Map<String, String> getLatestPackageVersions() {
+        return latestPackageVersions;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/nuget/utils/NugetPackageCheckerVisitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nuget/utils/NugetPackageCheckerVisitorTest.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.nuget.utils;
+
+import org.jenkinsci.plugins.nuget.NugetGlobalConfiguration;
+import org.jenkinsci.plugins.nuget.triggers.logs.TriggerLog;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.xml.sax.SAXParseException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NugetPackageCheckerVisitorTest {
+
+    NugetPackageCheckerVisitor visitor;
+    TriggerLog log;
+
+    @Before
+    public void setUp() throws Exception {
+        log = mock(TriggerLog.class);
+        NugetGlobalConfiguration configuration = mock(NugetGlobalConfiguration.class);
+        visitor = new NugetPackageCheckerVisitor(
+            log,
+            configuration,
+            true,
+            null
+        );
+        visitor.getLatestPackageVersions().put("Test", "1.0.0");
+    }
+
+    @Test
+    public void shouldNotBeVulnerableToXxe() throws URISyntaxException, IOException {
+        Path file = getFile("xxe");
+        FileVisitResult fileVisitResult = visitor.visitFile(file, null);
+
+        ArgumentCaptor<SAXParseException> exceptionArgumentCaptor = ArgumentCaptor.forClass(SAXParseException.class);
+        verify(log).errorWhileParsingPackageConfigFile(exceptionArgumentCaptor.capture());
+        SAXParseException exception = exceptionArgumentCaptor.getValue();
+        assertEquals(DOCTYPE_FORBIDDEN_ERROR, exception.getMessage());
+    }
+
+    private Path getFile(String path) throws URISyntaxException {
+        URL url = getClass()
+            .getClassLoader()
+            .getResource("NugetPackageCheckerVisitorTest/" + path + "/packages.config");
+        File file = new File(url.toURI());
+        return file.toPath();
+    }
+
+    final String DOCTYPE_FORBIDDEN_ERROR =
+        "DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true.";
+}

--- a/src/test/resources/NugetPackageCheckerVisitorTest/xxe/packages.config
+++ b/src/test/resources/NugetPackageCheckerVisitorTest/xxe/packages.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE packages [
+    <!ELEMENT packages (package)>
+    <!ELEMENT package (#PCDATA)>
+    <!ATTLIST package
+        id CDATA #REQUIRED
+        version CDATA #REQUIRED
+        targetFramework CDATA #REQUIRED
+    >
+    <!ENTITY xxe SYSTEM "file:///evil">
+]>
+<packages>
+  <package id="Test" version="1.0.0" targetFramework="net46" >&xxe;</package>
+</packages>


### PR DESCRIPTION
This is #25 except it resolves the merge conflict and fixes the build failures:

* Downgrade of Mockito to fix enforcer failure
* Two FindBugs issues (that are present on current master) addressed via suppression and throwing NPE explicitly.

I created this PR from a new branch to separate the "raw" `v1.1` with the security fix only from a branch with commits on top to make it mergeable.

----

https://www.jenkins.io/security/advisory/2021-05-25/#SECURITY-2340

This should be merged using merge commit via GH or CLI, NOT rebase or squash, to retain the release related commits in the history of the default branch.